### PR TITLE
Upload traced svg files to S3 CU-863fxa5vq

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,5 +4,8 @@ services:
     build: .
     environment:
       - PORT=8000
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - VECTORIZING_S3_BUCKET=${VECTORIZING_S3_BUCKET}
     ports:
       - "8000:8000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ flask
 opencv-python
 scikit-image
 pypotrace
+boto3
+cuid

--- a/src/app.py
+++ b/src/app.py
@@ -3,11 +3,19 @@ from flask import Flask, request
 from process_binary import process as process_binary
 from markup import build_markup
 from read import ReadError, ChannelCountError, SizeError
+import boto3
+import cuid
+import json
+import check_variables
+
+check_variables(); # Halt if the required environment variables are not defined
 
 app = Flask(__name__)
 
 NO_URL_ERROR = 'Image URL not provided.'
 PORT = os.environ['PORT']
+S3_UPLOADS_BUCKET = os.environ['VECTORIZING_S3_BUCKET']
+S3 = boto3.client("s3")
 
 @app.route('/', methods = ['GET'])
 def process():
@@ -27,8 +35,14 @@ def process():
             img_width,
             img_height
         )
-        
-        return markup
+        cuidStr = cuid.cuid()
+        S3.put_object(
+            Body=markup.encode('utf-8'),
+            Bucket=S3_UPLOADS_BUCKET,
+            Key=cuidStr,
+            ContentType="image/svg+xml",
+        )
+        return json.dumps({ "objectId": cuidStr })
     
     except (ReadError, ChannelCountError, SizeError) as e:
         return str(e), 400

--- a/src/check_variables.py
+++ b/src/check_variables.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+REQUIRED_ENVIRONMENT_VARIABLES=['PORT', 'VECTORIZING_S3_BUCKET', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY'];
+
+class VariableNotDefinedException(Exception):
+    pass
+
+def check_variables():
+    for env in REQUIRED_ENVIRONMENT_VARIABLES:
+        if not os.environ.get(env):
+            raise VariableNotDefinedException(env);
+
+sys.modules[__name__] = check_variables


### PR DESCRIPTION
Instead of returning the svg markup when vectorizing an image, upload the svg file to an s3 bucket.

To test this, the following environment variables must be defined locally: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `VECTORIZING_S3_BUCKET`