### PR TITLE
Add empty rectangle to output

### DIFF
--- a/src/markup.py
+++ b/src/markup.py
@@ -67,5 +67,6 @@ def build_markup (potrace_paths, colors, img_width, img_height):
     return (
         f'<svg xmlns="http://www.w3.org/2000/svg" width="{img_width}" height="{img_height}" viewBox="0 0 {img_width} {img_height}">\n'
         f'<g>\n{paths_markup}\n</g>\n'
+        f'<rect x="0" y="0" width="{img_width}" height="{img_height}" fill="transparent" class="kittl-util_ignore-outline"/>'
         f'</svg>'
     )


### PR DESCRIPTION
We need a rectangle to match the outputted vector image with the raster image in the editor. Otherwise the bounding box of the two might differ and it's impossible to know where to place things.

I added the `kittl-util_ignore-outline` class so that we can filter it out in the editor when computing the outline path