### PR TITLE
Improve log format

### DIFF
--- a/src/server/logs.py
+++ b/src/server/logs.py
@@ -4,12 +4,30 @@ def setup_logs():
     # Set up Flask logging to STDOUT
     dictConfig({
         'version': 1,
-        'handlers': {'wsgi': {
-            'class': 'logging.StreamHandler',
-            'stream': 'ext://sys.stdout',
-        }},
-        'root': {
-            'level': 'INFO',
-            'handlers': ['wsgi']
+        'formatters': 
+            {
+            'default': 
+                {
+                'format': '[%(levelname)s] %(message)s'
+                }
+            },
+        'handlers': 
+            {
+            'stdout': 
+                {
+                'class': 'logging.StreamHandler',
+                'formatter': 'default', 
+                'stream': 'ext://sys.stdout'
+                }
+            }, 
+        'loggers': 
+            {
+            '': 
+                {                  
+                'handlers': ['stdout'],    
+                'level': 'INFO',    
+                'propagate': True 
+                }
+            }
         }
-    })
+    )


### PR DESCRIPTION
Change the log format so the level is printed. For example:

`[INFO] Vectorizing server running on port: 8000, environment: development`

or

`[ERROR] An error occurred (NoSuchBucket) when calling the PutObject operation: The specified bucket does not exist` 

This will allows us to filter for all errors in logs by searching for: `[ERROR]`