### PR TITLE
Do not attempt to run image in deploy CU-861n31qn4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,6 @@ jobs:
       - name: Publish the Docker image
         run: |
           docker build . --tag ghcr.io/kittl/vectorizing:${{ github.ref_name }}
-          docker run ghcr.io/kittl/vectorizing:${{ github.ref_name }}
           docker push ghcr.io/kittl/vectorizing:${{ github.ref_name }}
       - name: Deploy vectorizing in staging cluster
         uses: kodermax/kubectl-aws-eks@master


### PR DESCRIPTION
We shouldn't be running the image before pushing because now contains a `CMD` line at the end, meaning it will attempt to run the app in the action.