### PR TITLE
Expose tolerance param CU-86c3mbjx8

### DIFF
--- a/vectorizing/geometry/bounds.py
+++ b/vectorizing/geometry/bounds.py
@@ -34,19 +34,19 @@ def compute_total_bounds(bounds_list):
     )
 
 # Calculates bounds of a path made out CubicBeziers and SegmentLists
-def path_bounds(path):
-    bounds = [item.bounds() for item in path]
+def path_bounds(path, tolerance):
+    bounds = [item.bounds(tolerance) for item in path]
     return compute_total_bounds(bounds)
 
 # Calculates bounds of a compound path, meaning a list of paths
-def compound_path_bounds(compound_path):
-    bounds = [path_bounds(path) for path in compound_path]
+def compound_path_bounds(compound_path, tolerance):
+    bounds = [path_bounds(path, tolerance) for path in compound_path]
     return compute_total_bounds(bounds)
 
 # Calculates bounds of a list of compound paths
-def compound_path_list_bounds(compound_path_list):
+def compound_path_list_bounds(compound_path_list, tolerance):
     bounds = [
-        compound_path_bounds(compound_path) 
+        compound_path_bounds(compound_path, tolerance)
         for compound_path in compound_path_list
         if len(compound_path) > 0
     ]

--- a/vectorizing/geometry/cubic_bezier.py
+++ b/vectorizing/geometry/cubic_bezier.py
@@ -79,14 +79,14 @@ def subdivide(points):
     )
 
 @njit
-def flatten(points):
+def flatten(points, tolerance):
     stack = [points]
     flattened = []
 
     while len(stack):
         first = stack.pop()
 
-        if is_flat_enough(first):
+        if is_flat_enough(first, tolerance):
             flattened.append(first[0])
             flattened.append(first[1])
         
@@ -113,9 +113,9 @@ class CubicBezier:
             self.p3 * s
         )
     
-    def flattened(self):
+    def flattened(self, tolerance):
         points = (tuple(self.p0), tuple(self.p1), tuple(self.p2), tuple(self.p3))
-        return SegmentList(np.array(flatten(points)))
+        return SegmentList(np.array(flatten(points, tolerance)))
     
-    def bounds(self):
-        return self.flattened().bounds()
+    def bounds(self, tolerance):
+        return self.flattened(tolerance).bounds()

--- a/vectorizing/geometry/potrace.py
+++ b/vectorizing/geometry/potrace.py
@@ -55,8 +55,11 @@ def unfold_polygon(folded_polygon):
 # Given a compound path, it converts it to a compound polygon
 # by flattening curves.
 # All coordinates can be scaled for convenience (see pyclipper)
-def compound_path_to_compound_polygon(compound_path, scale = 1):
-    polygons = [[item.flattened().scaled(scale) for item in path] for path in compound_path]
+def compound_path_to_compound_polygon(compound_path, tolerance, scale=1):
+    polygons = [
+        [item.flattened(tolerance).scaled(scale) for item in path]
+        for path in compound_path
+    ]
     return [unfold_polygon(folded_polygon) for folded_polygon in polygons]
 
 # Given a compound polygon, it converts it to a compound path.

--- a/vectorizing/geometry/segment_list.py
+++ b/vectorizing/geometry/segment_list.py
@@ -11,7 +11,7 @@ class SegmentList:
     def scaled(self, s):
         return SegmentList(self.points * s)
 
-    def flattened(self):
+    def flattened(self, _):
         return self
     
     def to_list(self):

--- a/vectorizing/solvers/color/ColorSolver.py
+++ b/vectorizing/solvers/color/ColorSolver.py
@@ -7,11 +7,12 @@ from vectorizing.solvers.color.clip import remove_layering
 from vectorizing.solvers.color.bitmaps import create_bitmaps
 
 class ColorSolver:
-    def __init__(self, img, color_count, timer):
+    def __init__(self, img, color_count, tolerance, timer):
         color_count = color_count or ColorSolver.DEFAULT_COLOR_COUNT
         color_count = max(color_count, ColorSolver.MIN_COLOR_COUNT)
         color_count = min(color_count, ColorSolver.MAX_COLOR_COUNT)
         self.color_count = color_count
+        self.tolerance = tolerance
 
         self.img = limit_size(img)
         
@@ -34,7 +35,7 @@ class ColorSolver:
         self.timer.end_timer()
 
         self.timer.start_timer('Polygon Clipping')
-        compound_paths = remove_layering(traced_bitmaps)
+        compound_paths = remove_layering(traced_bitmaps, self.tolerance)
         self.timer.end_timer()
         
         return [

--- a/vectorizing/solvers/color/clip.py
+++ b/vectorizing/solvers/color/clip.py
@@ -13,14 +13,14 @@ SCALE = 1_000_000
 
 # NOTE: The clipper library uses integer coordinates only for numerical robustness.
 # That's why coordinates are scaled by a big factor, to preserve precision.
-def remove_layering(traced_bitmaps):
+def remove_layering(traced_bitmaps, tolerance):
     compound_paths = [
         potrace_path_to_compound_path(traced) 
         for traced in traced_bitmaps
     ]
 
     compound_polygons = [
-        compound_path_to_compound_polygon(compound_path, SCALE) 
+        compound_path_to_compound_polygon(compound_path, tolerance, SCALE) 
         for compound_path in compound_paths
     ]
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->
**Description:**

This PR exposes a tolerance parameter for vectorizing requests. Lower tolerances means higher resolution SVG's are created. The default is set to 0.2 which is what we had before. To test, you can make normal requests, just add the "tolerance" parameter to the body with something other than 0.2.

<!-- ignore-task-list-end -->
**Checklist (based on [PR guidelines](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2)):**

- [x] I have self-reviewed this PR, according to [these points](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2?pvs=4#cce74429793a46aa9e448cbe8ed97221)
- [x] This PR falls into maximum three of [these categories](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2?pvs=4#bc286233220540079736bb5460c562dc)
- [x] I feel comfortable taking responsibility for merging this code to production
- [x] The code is high quality, [well-tested](https://www.notion.so/kittl/Unit-testing-guide-4ff179324baa42f08af2a88d1408e901), follows styles guides ([Frontend](https://www.notion.so/kittl/Kittl-Frontend-Code-Style-65978cb3d3134936960bff045b92972f)), clean, and well documented
