### PR TITLE
Add missing `flattened` param

### DIFF
--- a/vectorizing/geometry/segment_list.py
+++ b/vectorizing/geometry/segment_list.py
@@ -17,7 +17,7 @@ class SegmentList:
     def to_list(self):
         return list(self.points)
     
-    def bounds(self):
+    def bounds(self, _):
         t = self.points.T
         x = t[0]
         y = t[1]


### PR DESCRIPTION
Adding missing parameter to `SegmentList.bounds`. Same as `flattened`. Unused but needed for interfaces to match
