### PR TITLE
Minimize bad cases CU-86c3mbjx8

### DIFF
--- a/vectorizing/solvers/color/ColorSolver.py
+++ b/vectorizing/solvers/color/ColorSolver.py
@@ -35,7 +35,7 @@ class ColorSolver:
         self.timer.end_timer()
 
         self.timer.start_timer("Polygon Clipping")
-        compound_paths = remove_layering(traced_bitmaps)
+        compound_paths = remove_layering(traced_bitmaps, self.img)
         self.timer.end_timer()
 
         return [compound_paths, colors, self.img.size[0], self.img.size[1]]

--- a/vectorizing/solvers/color/clip.py
+++ b/vectorizing/solvers/color/clip.py
@@ -1,23 +1,70 @@
-from pathops import op, PathOp
+from pathops import op, PathOp, Path
 from vectorizing.geometry.potrace import potrace_path_to_compound_path
 
-def remove_layering(traced_bitmaps):
+def create_background_rect(img, padding):
+    """
+    Creates a rectangle that matches the image dimensions plus
+    some padding.
+
+        Parameters:
+            img: A Pillow image instance.
+
+        Returns:
+            The rectangle.
+    """
+    rect = Path()
+    rect.moveTo(-padding, -padding)
+    rect.lineTo(img.width + padding, -padding)
+    rect.lineTo(img.width + padding, img.height + padding)
+    rect.lineTo(-padding, img.height + padding)
+    rect.close()
+    return rect
+
+def remove_layering(traced_bitmaps, img):
     """
     Performs boolean operations on a list of traced bitmaps
     to ensure that they are all disjoint.
 
-            Parameters:
-                traced_bitmaps: The list of traced bitmaps (potrace paths).
+    This function uses a technique devised to try to minimize
+    the holes created / outright failures of SKPath boolean operations.
+    Even so, a failure can still happen (and often does), particularly
+    for very intricate paths (usually coming from real world photographs).
+    In such cases, the routine fallbacks to a mixture of disjoint paths
+    (the ones for which the boolean operations didn't fail), and layered paths.
 
-            Returns:
-                The processed list of compound paths.
+        Parameters:
+            traced_bitmaps: The list of traced bitmaps (potrace paths).
+            img: A Pillow image.
+
+        Returns:
+            The processed list of compound paths.
     """
     compound_paths = [
         potrace_path_to_compound_path(traced) for traced in traced_bitmaps
     ]
 
+    disjoint_paths = []
     for x in range(len(compound_paths) - 1):
-        next = compound_paths[x + 1]
-        compound_paths[x] = op(compound_paths[x], next, PathOp.DIFFERENCE)
+        # Each base path has bigger padding to reduce
+        # the amount of overlapping borders.
+        base = create_background_rect(img, (x + 1) * 10)
+        
+        to_subtract = Path()
+        for y in range(0, x):
+            to_subtract.addPath(disjoint_paths[y])
+        to_subtract.addPath(compound_paths[x + 1])
 
-    return compound_paths
+        try:
+            result = op(base, to_subtract, PathOp.DIFFERENCE)
+        except:
+            break
+        disjoint_paths.append(result)
+
+    for x in range(len(disjoint_paths)):
+        try:
+            disjoint_paths[x] = op(disjoint_paths[x], create_background_rect(img, 0), PathOp.INTERSECTION)
+        except:
+            return compound_paths
+
+    disjoint_paths = disjoint_paths + compound_paths[len(disjoint_paths) : len(compound_paths)]
+    return disjoint_paths


### PR DESCRIPTION
<!-- ignore-task-list-start -->
**Description:**

Changes how the boolean operations are performed. Instead of subtracting the next path from the current, we use a different approach that always subtracts from a rectangle covering the image + some padding. This helps reduce the amount of overlapping edges between the two paths involved in the boolean operation, which seems to be a big contributing factor to the creation of holes.

With this change I haven't seen holes created, but it does fail sometimes (same as before, maybe a bit more). In that case, we accept however many paths we could make disjoint and the rest are left untouched. In many cases (photographs, clip art with lots of raster content) results will be partially layered. But that should be outweighed by the fact that for most clip art illustrations, simpler, separate paths should be created. 

- [x] I have self-reviewed this PR, according to [these points](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2?pvs=4#cce74429793a46aa9e448cbe8ed97221)
- [x] This PR falls into maximum three of [these categories](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2?pvs=4#bc286233220540079736bb5460c562dc)
- [x] I feel comfortable taking responsibility for merging this code to production
- [x] The code is high quality, [well-tested](https://www.notion.so/kittl/Unit-testing-guide-4ff179324baa42f08af2a88d1408e901), follows styles guides ([Frontend](https://www.notion.so/kittl/Kittl-Frontend-Code-Style-65978cb3d3134936960bff045b92972f)), clean, and well documented
