### PR TITLE
Fix transparency CU-86c42m6a9

### DIFF
--- a/vectorizing/solvers/color/ColorSolver.py
+++ b/vectorizing/solvers/color/ColorSolver.py
@@ -35,7 +35,7 @@ class ColorSolver:
         self.timer.end_timer()
 
         self.timer.start_timer("Polygon Clipping")
-        compound_paths = remove_layering(traced_bitmaps, self.img)
+        compound_paths = remove_layering(traced_bitmaps, self.img, has_background)
         self.timer.end_timer()
 
         return [compound_paths, colors, self.img.size[0], self.img.size[1]]


### PR DESCRIPTION
<!-- ignore-task-list-start -->
**Description:**

Nothing new here, the old method for layering removal is brought back for images with a transparent background because the new method makes an assumption that is not true for those.

- [x] I have self-reviewed this PR, according to [these points](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2?pvs=4#cce74429793a46aa9e448cbe8ed97221)
- [x] This PR falls into maximum three of [these categories](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2?pvs=4#bc286233220540079736bb5460c562dc)
- [x] I feel comfortable taking responsibility for merging this code to production
- [x] The code is high quality, [well-tested](https://www.notion.so/kittl/Unit-testing-guide-4ff179324baa42f08af2a88d1408e901), follows styles guides ([Frontend](https://www.notion.so/kittl/Kittl-Frontend-Code-Style-65978cb3d3134936960bff045b92972f)), clean, and well documented
