### PR TITLE
ci(secrets): Use GH App instead of PAT CU-86c5w81vz

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,5 +11,5 @@ jobs:
     name: Deploy PY server Argo
     uses: ./.github/workflows/helpers-deploy-argo.yaml
     secrets:
-      GH_PAT: ${{ secrets.GH_PAT }}
+      KITTL_CI_APP_PRIVATE_KEY: ${{ secrets.KITTL_CI_APP_PRIVATE_KEY }}
       ECR_ROLE_ARN: ${{ github.ref == 'refs/heads/production' && secrets.PRODUCTION_ECR_ROLE_ARN || secrets.STAGING_ECR_ROLE_ARN }}

--- a/.github/workflows/helpers-deploy-argo.yaml
+++ b/.github/workflows/helpers-deploy-argo.yaml
@@ -6,8 +6,8 @@ name: helpers-deploy-argo
 on:
   workflow_call:
     secrets:
-      GH_PAT:
-        description: "The GitHub Personal Access Token to use for checking out the helm-config repository"
+      KITTL_CI_APP_PRIVATE_KEY:
+        description: "The Kittl-CICD GitHub App private key to use for generating a short-living token"
         required: true
       ECR_ROLE_ARN:
         description: "The ECR role ARN"
@@ -36,13 +36,22 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.KITTL_CI_APP_ID }}
+          private-key: ${{ secrets.KITTL_CI_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            development-applications-config
       - name: Checkout helm config Repository
         uses: actions/checkout@v4
         with:
           repository: Kittl/development-applications-config
           ref: main
           path: helm-config
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.KITTL_CI_APP_PRIVATE_KEY }}
           persist-credentials: false
       - name: Update Image Version in the related HelmChart values.yaml
         uses: fjogeleit/yaml-update-action@v0.14.0
@@ -54,5 +63,5 @@ jobs:
           branch: main
           createPR: false
           message: 'Update Image Version to ${{ needs.build-docker-image.outputs.image-tag }}'
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ secrets.KITTL_CI_APP_PRIVATE_KEY }}
           workDir: helm-config


### PR DESCRIPTION
<!-- ignore-task-list-start -->
**Description:**
Replaces org GH_PAT (highly privileges long-living token) for an ephemeral one generated by Kittl-CICD GH App.


<!-- ignore-task-list-end -->
**Checklist (based on [PR guidelines](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2)):**

- [x] I have self-reviewed this PR, according to [these points](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2?pvs=4#cce74429793a46aa9e448cbe8ed97221)
- [x] This PR falls into maximum three of [these categories](https://www.notion.so/kittl/Pull-request-review-guide-c820979d6b3a401a952bd15f6353fbc2?pvs=4#bc286233220540079736bb5460c562dc)
- [x] I feel comfortable taking responsibility for merging this code to production
